### PR TITLE
Add python3 support

### DIFF
--- a/plugin/ici.vim
+++ b/plugin/ici.vim
@@ -1,23 +1,36 @@
-function! Ici(word)
-python << endpython
-import vim
+function! s:UsingPython3()
+  if has('python3')
+    return 1
+  endif
+  return 0
+endfunction
 
-import sys
-import urllib2
-import getopt
+
+let s:using_python3 = s:UsingPython3()
+let s:python_until_eof = s:using_python3 ? "python3 << EOF" : "python << EOF"
+
+function! Ici(word)
+  exec s:python_until_eof
+import vim
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
 from xml.dom import minidom
 
-WORD= vim.eval("a:word")
+WORD = vim.eval("a:word")
 KEY = 'E0F0D336AF47D3797C68372A869BDBC5'
 URL = 'http://dict-co.iciba.com/api/dictionary.php'
 
 
 def get_response(word):
-    return urllib2.urlopen(URL + '?key=' + KEY + '&w=' + word)
+    return urlopen(URL + '?key=' + KEY + '&w=' + word)
+
 
 def read_xml(xml):
     dom = minidom.parse(xml)
     return dom.documentElement
+
 
 def show(node):
     if not node.hasChildNodes():
@@ -25,21 +38,22 @@ def show(node):
             tag_name = node.parentNode.tagName
             content = node.data.replace('\n', '')
             if tag_name == 'ps':
-                print content
-                print '---------------------------'
-            if tag_name == 'orig':
-                print content
-            if tag_name == 'trans':
-                print content
-                print '---------------------------'
-            if tag_name == 'pos':
-                print content
-            if tag_name == 'acceptation':
-                print content
-                print '---------------------------'
+                print(content)
+                print('---------------------------')
+            elif tag_name == 'orig':
+                print(content)
+            elif tag_name == 'trans':
+                print(content)
+                print('---------------------------')
+            elif tag_name == 'pos':
+                print(content)
+            elif tag_name == 'acceptation':
+                print(content)
+                print('---------------------------')
     else:
         for e in node.childNodes:
             show(e)
+
 
 def main():
     root = read_xml(get_response(WORD))
@@ -47,7 +61,7 @@ def main():
 
 if __name__ == '__main__':
     main()
-endpython
+EOF
 endfunction
 
 

--- a/plugin/ici.vim
+++ b/plugin/ici.vim
@@ -1,13 +1,14 @@
-function! s:UsingPython3()
-  if has('python3')
-    return 1
+let s:python_until_eof = "python3 << EOF"
+if !has("python3")
+  let s:python_until_eof = "python << EOF"
+  if !has("python")
+    echohl WarningMsg
+    echom  "Ici requires py >= 2.7 or py3"
+    echohl None
+    unlet s:python_until_eof
+    finish
   endif
-  return 0
-endfunction
-
-
-let s:using_python3 = s:UsingPython3()
-let s:python_until_eof = s:using_python3 ? "python3 << EOF" : "python << EOF"
+endif
 
 function! Ici(word)
   exec s:python_until_eof


### PR DESCRIPTION
The original version just supports python2. 
I add python3 support for it. 

And the plugin now can detect the whether py3 or py2 are supported in runtime, then decide to use witch version of python(Py3 is prefered).